### PR TITLE
fix: Handle long function names in IAM role naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed IAM role creation failure when `function_name` exceeds 37 characters
+- IAM role `name_prefix` now truncates function names longer than 37 characters to comply with AWS's 38-character limit
+- Removed redundant "-role-" suffix from IAM role names (now uses up to 37 characters of function name instead of 32)
+- Full function name is preserved in the IAM role's `function_name` tag for identification
+
 ### Added
 - **VPC Configuration Support**: Lambda functions can now be attached to VPC for accessing private resources
   - `lambda_subnet_ids` variable for specifying VPC subnets (must have NAT gateway)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ module "lambda" {
 
 ## Notes
 
+### IAM Role Naming
+
+If your `function_name` exceeds 37 characters, the IAM role name will be truncated to comply with AWS's 38-character `name_prefix` limit. The full function name is always preserved in the IAM role's `function_name` tag for identification purposes.
+
+**Best Practice:** Reference the IAM role using the module outputs (`lambda_role_arn` or `lambda_role_name`) rather than constructing the role name manually.
+
 ### Email Subscription Confirmation
 
 When you specify `alarm_emails`, AWS will send a confirmation email to each address.

--- a/lambda_iam.tf
+++ b/lambda_iam.tf
@@ -16,11 +16,16 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 
 # IAM role for Lambda execution
 resource "aws_iam_role" "lambda" {
-  name_prefix = "${var.function_name}-role-"
+  name_prefix = "${substr(var.function_name, 0, min(length(var.function_name), 37))}-"
 
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    {
+      function_name = var.function_name
+    }
+  )
 }
 
 # IAM policy document for CloudWatch Logs


### PR DESCRIPTION
- Truncate function_name to 37 characters in IAM role name_prefix to comply with AWS 38-char limit
- Remove redundant "-role-" suffix from role names
- Preserve full function_name in IAM role tag for identification
- Add release-patch/minor/major Makefile targets with branch protection
- Document IAM role naming behavior in README

Fixes error when function_name exceeds 37 characters:
"expected length of name_prefix to be in the range (1 - 38)"
