### PR TITLE
fix: Resolve IAM role naming and policy attachment issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.3] - 2025-11-09
+### Fixed
+- Fixed `for_each` error when `additional_iam_policy_arns` contains computed values by switching to `count`
 
-## [0.3.2] - 2025-11-09
+## [0.3.3] - 2025-11-09
 
 ### Fixed
 - Fixed IAM role creation failure when `function_name` exceeds 37 characters

--- a/lambda_iam.tf
+++ b/lambda_iam.tf
@@ -139,8 +139,8 @@ resource "aws_iam_role_policy" "lambda_vpc_access" {
 
 # Attach additional IAM policies to Lambda role
 resource "aws_iam_role_policy_attachment" "additional" {
-  for_each = toset(var.additional_iam_policy_arns)
+  count = length(var.additional_iam_policy_arns)
 
   role       = aws_iam_role.lambda.name
-  policy_arn = each.value
+  policy_arn = var.additional_iam_policy_arns[count.index]
 }


### PR DESCRIPTION
- Fix for_each error by switching additional_iam_policy_arns from for_each to count
