### PR TITLE
fix: handle null value in duration_threshold_percent validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -205,7 +205,7 @@ variable "duration_threshold_percent" {
   default     = null
 
   validation {
-    condition     = var.duration_threshold_percent == null || (var.duration_threshold_percent > 0 && var.duration_threshold_percent <= 100)
+    condition     = var.duration_threshold_percent == null ? true : (var.duration_threshold_percent > 0 && var.duration_threshold_percent <= 100)
     error_message = "Duration threshold percent must be between 1 and 100"
   }
 }


### PR DESCRIPTION
The validation condition for duration_threshold_percent was failing when
the variable was null (its default value) because Terraform doesn't
properly short-circuit the OR operator with comparison operators.

Changed from:
```
  var.duration_threshold_percent == null || (condition)
```
To:
```
  var.duration_threshold_percent == null ? true : (condition)
```

This prevents the comparison operators from being evaluated on null values,
fixing the "argument must not be null" error when the variable is not
explicitly set by module consumers.
