### PR TITLE
fix: sanitize function name for S3 bucket naming compatibility

### DIFF
--- a/lambda_s3.tf
+++ b/lambda_s3.tf
@@ -6,7 +6,7 @@ module "lambda_bucket" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
   version = "0.2.0"
 
-  bucket_prefix = substr("${var.function_name}-lambda", 0, 37)
+  bucket_prefix = substr("${local.sanitized_function_name}-lambda", 0, 37)
   tags = merge(
     local.tags,
     {

--- a/locals.tf
+++ b/locals.tf
@@ -8,6 +8,16 @@ locals {
 
   tags = merge(var.tags, local.default_module_tags)
 
+  # Sanitize function name for S3 bucket (S3 only allows lowercase alphanumeric and hyphens)
+  # Original function name is preserved in tags
+  sanitized_function_name = lower(
+    replace(
+      replace(var.function_name, "_", "-"),
+      "/[^a-z0-9-]/",
+      ""
+    )
+  )
+
   # Auto-detect requirements.txt in lambda_source_dir if not explicitly specified
   requirements_txt_path = "${var.lambda_source_dir}/requirements.txt"
   requirements_file = var.requirements_file != null ? var.requirements_file : (


### PR DESCRIPTION
S3 bucket names only allow lowercase alphanumeric characters and hyphens,
but Lambda function names can contain uppercase letters and underscores.
This caused validation errors when function names like "update-dns_ASG_Name"
were used.

Changes:
- Add sanitized_function_name local that converts function name to lowercase,
  replaces underscores with hyphens, and removes all other invalid characters
- Update lambda_bucket module to use sanitized name for bucket_prefix
- Preserve original function_name and sanitized_function_name in S3 bucket
  tags for traceability

This ensures S3 bucket names are always valid while maintaining the original
function name for reference and debugging.
