### PR TITLE
fix: ensure Lambda dependencies are installed on module upgrades

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "this" {
   s3_bucket = aws_s3_object.lambda_package.bucket
   s3_key    = aws_s3_object.lambda_package.key
 
-  source_code_hash = data.archive_file.lambda_source_hash.output_base64sha256
+  source_code_hash = local.source_code_hash
 
   dynamic "environment" {
     for_each = length(var.environment_variables) > 0 ? [1] : []

--- a/lambda_s3.tf
+++ b/lambda_s3.tf
@@ -18,11 +18,11 @@ module "lambda_bucket" {
 # Upload Lambda package to S3
 resource "aws_s3_object" "lambda_package" {
   bucket = module.lambda_bucket.bucket_name
-  key    = "${var.function_name}/${data.archive_file.lambda_source_hash.output_md5}.zip"
-  source = data.archive_file.lambda_source_hash.output_path
+  key    = "${var.function_name}/${local.package_hash}.zip"
+  source = local.zip_output_path
 
   depends_on = [
-    null_resource.install_python_dependencies
+    null_resource.lambda_package
   ]
 
   tags = local.tags
@@ -33,7 +33,7 @@ resource "aws_s3_object" "lambda_package" {
       "${path.module}/scripts/wait_for_s3_object.sh",
       {
         bucket_name       = module.lambda_bucket.bucket_name
-        object_key        = "${var.function_name}/${data.archive_file.lambda_source_hash.output_md5}.zip"
+        object_key        = "${var.function_name}/${local.package_hash}.zip"
         caller_account_id = data.aws_caller_identity.current.account_id
         caller_arn        = data.aws_caller_identity.current.arn
       }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,9 @@ def create_terraform_config(
           lambda_security_group_ids = {json.dumps(security_group_ids)}
         """
 
+    # Convert path to forward slashes for Terraform (Windows compatibility)
+    lambda_source_dir_normalized = str(lambda_source_dir).replace('\\', '/')
+
     main_tf = dedent(
         f'''
         {sg_resource}
@@ -195,7 +198,7 @@ def create_terraform_config(
           source = "./.."  # Points to the root module
 
           function_name     = "{function_name}"
-          lambda_source_dir = "{str(lambda_source_dir).replace('\\', '/')}"
+          lambda_source_dir = "{lambda_source_dir_normalized}"
           python_version    = "{python_version}"
           architecture      = "{architecture}"
           alert_strategy    = "{alert_strategy}"

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -241,7 +241,7 @@ class TestLambdaWithDependencies:
 
             # Parse response
             payload = json.loads(response["Payload"].read())
-            assert payload["statusCode"] == 200
+            assert payload["statusCode"] == 200, f"Status code != 200 in payload: {payload}"
 
             # Verify requests library worked
             body = json.loads(payload["body"])


### PR DESCRIPTION
When upgrading the terraform-aws-lambda-monitored module (e.g., 1.0.0 → 1.0.3),
Lambda deployments would fail because dependencies were not reinstalled if:
- Source code hadn't changed
- requirements.txt hadn't changed
- Architecture/Python version hadn't changed

This happened because:
1. Build directory = source directory (dependencies installed in-place)
2. Source directories have .gitignore excluding dependencies
3. null_resource triggers didn't include module_version
4. data.archive_file evaluated during plan phase before dependencies installed

Result: New Lambda package deployed WITHOUT dependencies → runtime failures

- Build in separate `.build/` directory instead of source directory
- Package script now creates zip file directly (no data.archive_file)
- Added `module_version` to null_resource triggers
- Added `package_hash` to triggers for comprehensive change detection
- Source directories stay clean (no dependency pollution)

- Updated `package.sh` to accept zip output path and create archive
- Converted zip path to absolute before cd'ing into build directory
- Replaced `data.archive_file` with direct zip creation in script
- Source hash now computed from package_hash (more reliable)

- Fixed Python 3.11 compatibility (f-string backslash escaping)
- Made test fixture resilient to httpbin.org outages (fallback to httpbun.com)

- Dependencies now ALWAYS installed fresh on module upgrades
- Source directories remain clean (build artifacts in .build/)
- More reliable Lambda deployments
- Better test resilience

Fixes the issue where module upgrades would deploy broken Lambda functions
without dependencies.
