### PR TITLE
Exempt lambda deployment bucket from Vanta CRR test

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda_bucket"></a> [lambda\_bucket](#module\_lambda\_bucket) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.3.1 |
+| <a name="module_lambda_bucket"></a> [lambda\_bucket](#module\_lambda\_bucket) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.6.0 |
 
 ## Resources
 

--- a/lambda_s3.tf
+++ b/lambda_s3.tf
@@ -4,9 +4,12 @@ data "aws_caller_identity" "current" {}
 # S3 bucket for Lambda deployment packages
 module "lambda_bucket" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
-  version = "0.3.1"
+  version = "0.6.0"
 
   bucket_prefix = substr("${local.sanitized_function_name}-lambda", 0, 37)
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Lambda deployment artifact bucket - ephemeral build output. No DR value"
+  }
   tags = merge(
     local.tags,
     {


### PR DESCRIPTION
## Summary
- Upgrade `infrahouse/s3-bucket/aws` from 0.3.1 to 0.6.0
- Add `vanta_exemptions` for `aws-s3-cross-region-replication-enabled` on the lambda deployment artifact bucket
- These buckets store ephemeral build output reproducible from CI — cross-region replication adds no DR value

Closes #27
Resolves: INF-1550

## Test plan
- [ ] `terraform init` succeeds with the new module version
- [ ] `terraform plan` shows the exemption tag added to existing lambda buckets
- [ ] Verify Vanta reconciler picks up the new tag on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)